### PR TITLE
fix data type for milliseconds overflow

### DIFF
--- a/SKO_Game/SKO_Player.h
+++ b/SKO_Game/SKO_Player.h
@@ -122,8 +122,8 @@ class SKO_Player
         SKO_PartyStatus partyStatus;
 
         //fun server stuff
-        unsigned long long int loginTime;
-        unsigned long long int minutesPlayed;
+        unsigned long int loginTime;
+        unsigned long int minutesPlayed;
         unsigned short int OS;
         unsigned long int mobKills;
         unsigned long int pvpKills;

--- a/SKO_Network/SKO_Network.cpp
+++ b/SKO_Network/SKO_Network.cpp
@@ -10,7 +10,7 @@
 //TODO remove this when possible
 #include "../Global.h"
 
-SKO_Network::SKO_Network(SKO_Repository *repository, int port, unsigned long int saveRateSeconds)
+SKO_Network::SKO_Network(SKO_Repository *repository, int port, unsigned long long int saveRateSeconds)
 {
 	// Bind this port to accept connections
 	this->port = port;

--- a/SKO_Network/SKO_Network.h
+++ b/SKO_Network/SKO_Network.h
@@ -27,7 +27,7 @@ class SKO_Network
  
 public:
 
-	SKO_Network(SKO_Repository * repository, int port, unsigned long int saveRateSeconds);
+	SKO_Network(SKO_Repository * repository, int port, unsigned long long int saveRateSeconds);
 	std::string startup();
 	void cleanup();
 
@@ -149,7 +149,7 @@ public:
 	std::mutex saveMutex;
 
 	// How often to save all valid players.
-	unsigned long int saveRateSeconds;
+	unsigned long long int saveRateSeconds;
 	unsigned long long int lastSaveTime;
 	
 	// Do not spam the database status table if there have been 0 players online for some time.

--- a/SKO_Repository/SKO_Repository.cpp
+++ b/SKO_Repository/SKO_Repository.cpp
@@ -768,7 +768,7 @@ bool SKO_Repository::savePlayerData(unsigned char userId)
 	total_minutes_played += (unsigned long long int)(this_session_milli/1000.0/60.0);
 
 	sql << ", minutes_played=";
-	sql << (int)total_minutes_played;
+	sql << total_minutes_played;
 
 		
 	//what map are they on?

--- a/SKO_Utilities/OPI_Clock.h
+++ b/SKO_Utilities/OPI_Clock.h
@@ -8,22 +8,22 @@ using namespace std::chrono;
 class OPI_Clock
 {
 public:
-    static unsigned long long nanoseconds()
+    static unsigned long long int nanoseconds()
     {
         return time_point_cast<std::chrono::nanoseconds>(system_clock::now())
             .time_since_epoch().count();
     }
-    static unsigned long long microseconds()
+    static unsigned long long int microseconds()
     {
         return time_point_cast<std::chrono::microseconds>(system_clock::now())
             .time_since_epoch().count();
     }
-    static unsigned long long milliseconds()
+    static unsigned long long int milliseconds()
     {
         return time_point_cast<std::chrono::milliseconds>(system_clock::now())
             .time_since_epoch().count();
     }
-    static unsigned long long seconds()
+    static unsigned long long int seconds()
     {
         return time_point_cast<std::chrono::seconds>(system_clock::now())
             .time_since_epoch().count();


### PR DESCRIPTION
fix cpu spin on milliseconds overflow with correct datatype in save loop